### PR TITLE
Fix : 게시물 조회 시 이미지도 같이 조회 되게끔 쿼리 수정

### DIFF
--- a/src/post/post.repository.ts
+++ b/src/post/post.repository.ts
@@ -1,7 +1,7 @@
 import { CustomRepository } from 'src/decorator/typeorm-ex.decorator';
 import { Repository } from 'typeorm';
 import { Post } from 'src/entity/post.entity';
-import { likes, hashtags } from 'src/query/subQuery';
+import { likes, hashtags, postImages } from 'src/query/subQuery';
 import { CreatePostDao } from 'src/dao/createPost.dao';
 import { User } from 'src/entity/user.entity';
 import { UpdatePostDao } from 'src/dao/updatePost.dao';
@@ -63,10 +63,12 @@ export class PostRepository extends Repository<Post> {
         'COALESCE(posts.hits,0)::int AS hits',
         'users.name AS username',
         'hashtags.hashtags',
+        '"postImages".images',
         'COALESCE(likes.like_num,0)::int AS like_num',
       ])
       .leftJoin('posts.user', 'users')
-      .leftJoin(likes, 'likes', 'posts.id = likes.postId');
+      .leftJoin(likes, 'likes', 'posts.id = likes.postId')
+      .leftJoin(postImages, 'postImages', 'posts.id = "postImages"."postId"');
 
     query = findPostsQuery(query, findPostsDao);
 
@@ -84,11 +86,13 @@ export class PostRepository extends Repository<Post> {
         'COALESCE(posts.hits,0)::int AS hits',
         'users.name AS username',
         'hashtags.hashtags',
+        '"postImages".images',
         'COALESCE(likes.like_num,0)::int AS like_num',
       ])
       .leftJoin('posts.user', 'users')
       .leftJoin(hashtags, 'hashtags', 'posts.id = hashtags.postId')
       .leftJoin(likes, 'likes', 'posts.id = likes.postId')
+      .leftJoin(postImages, 'postImages', 'posts.id = "postImages"."postId"')
       .where('posts.id = :id', { id })
       .getRawOne();
 

--- a/src/query/subQuery.ts
+++ b/src/query/subQuery.ts
@@ -16,3 +16,16 @@ export const hashtags = (subQuery) => {
     .leftJoin('posts.hashtags', 'hashtags')
     .groupBy('posts.id');
 };
+
+// postId 별 postImage 배열을 return 하는 subQuery
+
+export const postImages = (subQuery) => {
+  return subQuery
+    .select([
+      'posts.id AS "postId"',
+      'ARRAY_AGG(postImages.imageUrl) AS images',
+    ])
+    .from(Post, 'posts')
+    .leftJoin('posts.postImages', 'postImages')
+    .groupBy('posts.id');
+};


### PR DESCRIPTION
PR 타입(하나 이상의 PR 타입을 선택해주세요)
-[] 기능 추가
-[] 기능 삭제
-[V] 버그 수정
-[] 의존성, 환경 변수, 빌드 관련 코드 업데이트
-[] 리팩토링
-[] 테스트 추가

반영 브랜치

feature/post -> main

변경 사항

기존 쿼리는 게시물 조회 시 이미지가 같이 조회되지 않았었는데 수정된 쿼리에서는 이미지도 같이 조회되도록 수정